### PR TITLE
ci: update black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--line-length=100]


### PR DESCRIPTION
Signed-off-by: yukke42 <yukke42@users.noreply.github.com>

## PR Type

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] ci: Changes to our CI configuration files and scripts (example scopes: GitHub Actions)

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

- https://stackoverflow.com/a/71674345

## Description

<!-- Describe what this PR changes. -->

```
Traceback (most recent call last):
  File "/home/yusuke/.cache/pre-commit/repod9vfwgx7/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/yusuke/.cache/pre-commit/repod9vfwgx7/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1423, in patched_main
    patch_click()
  File "/home/yusuke/.cache/pre-commit/repod9vfwgx7/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1409, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/home/yusuke/.cache/pre-commit/repod9vfwgx7/py_env-python3/lib/python3.8/site-packages/click/__init__.py)
```
